### PR TITLE
Expanded Db support for Zend_Application_Resource_Multidb

### DIFF
--- a/zf1/Akrabat/Tool/DatabaseSchemaProvider.php
+++ b/zf1/Akrabat/Tool/DatabaseSchemaProvider.php
@@ -112,8 +112,19 @@ class Akrabat_Tool_DatabaseSchemaProvider extends Zend_Tool_Project_Provider_Abs
     protected function _getDbAdapter()
     {
         if ((null === $this->_db)) {
-            $dbConfig = $this->_config->resources->db;
-            $this->_db = Zend_Db::factory($dbConfig->adapter, $dbConfig->params);
+        	if($this->_config->resources->db){
+        		$dbConfig = $this->_config->resources->db;
+            	$this->_db = Zend_Db::factory($dbConfig->adapter, $dbConfig->params);
+        	} elseif($this->_config->resources->multidb){
+        		foreach ($this->_config->resources->multidb as $db) {
+        			if($db->default){
+        				$this->_db = Zend_Db::factory($db->adapter, $db);
+        			}
+        		}
+        	}
+        	if($this->_db instanceof Zend_Db_Adapter_Interface) {
+        		throw new Akrabat_Db_Schema_Exception('Database was not');
+        	}
         }
         return $this->_db;
     }

--- a/zf2/Akrabat/Tool/DatabaseSchemaProvider.php
+++ b/zf2/Akrabat/Tool/DatabaseSchemaProvider.php
@@ -112,13 +112,24 @@ class DatabaseSchemaProvider
     /**
      * Retrieve initialized DB connection
      *
-     * @return Zend_Db_Adapter_Interface
+     * @return \Zend\Db\Adapter\AbstractAdapter
      */
     protected function _getDbAdapter()
     {
         if ((null === $this->_db)) {
-            $dbConfig = $this->_config->resources->db;
-            $this->_db = \Zend\Db\Db::factory($dbConfig->adapter, $dbConfig->params);
+        	if($this->_config->resources->db){
+        		$dbConfig = $this->_config->resources->db;
+            	$this->_db = \Zend\Db\Db::factory($dbConfig->adapter, $dbConfig->params);
+        	} elseif($this->_config->resources->multidb){
+        		foreach ($this->_config->resources->multidb as $db) {
+        			if($db->default){
+        				$this->_db = \Zend\Db\Db::factory($db->adapter, $db);
+        			}
+        		}
+        	}
+        	if($this->_db instanceof \Zend\Db\Adapter\AbstractAdapter) {
+        		throw new Akrabat\Db\Schema\Exception('Database was not initialized');
+        	}
         }
         return $this->_db;
     }


### PR DESCRIPTION
Additional support added for Multidp resourcing, it selects the default params. I may extend this to support specification of adapter within migration classes if there is interest or need.
