### PR TITLE
local.ini config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.project
+/.settings
+/.buildpath

--- a/zf1/Akrabat/Tool/DatabaseSchemaProvider.php
+++ b/zf1/Akrabat/Tool/DatabaseSchemaProvider.php
@@ -99,23 +99,221 @@ class Akrabat_Tool_DatabaseSchemaProvider extends Zend_Tool_Project_Provider_Abs
         }
         $appConfigFilePath = $appConfigFileResource->getPath();
 
-        $this->_config = new Zend_Config_Ini(
-            $appConfigFilePath,
-            $env,
-            array('allowModifications' => true)
-        );
+        // Base config, normally the application.ini in the configs dir of your app
+        $this->_config = $this->_createConfig($appConfigFilePath, $env, true);
 
-        $appConfigFilePathLocal = dirname($appConfigFilePath).'/local.ini';
-        if (file_exists($appConfigFilePathLocal)) {
-            $localConfig = new Zend_Config_Ini($appConfigFilePathLocal);
-            if (isset($localConfig->$env)) {
-                $this->_config->merge($localConfig->$env);
+        // Are there any override config files?
+        foreach($this->_getAppConfigOverridePathList($appConfigFilePath) as $path) {
+            $overrideConfig = $this->_createConfig($path);
+            if (isset($overrideConfig->$env)) {
+                $this->_config->merge($overrideConfig->$env);
             }
         }
 
         require_once 'Zend/Loader/Autoloader.php';
         $autoloader = Zend_Loader_Autoloader::getInstance();
         $autoloader->registerNamespace('Akrabat_');
+    }
+
+    /**
+     * Pull the akrabat section of the zf.ini
+     *
+     *  @return Zend_Config_Ini|false Fasle if not set
+     */
+    protected function _getUserConfig()
+    {
+        $userConfig = false;
+        if (isset($this->_registry->getConfig()->akrabat)) {
+            $userConfig = $this->_registry->getConfig()->akrabat;
+        }
+        return $userConfig;
+    }
+
+    /**
+     * Create new Zend_Config object based on a filename
+     *
+     * Mostly a copy and paste from Zend_Application::_loadConfig
+     *
+     * @param string $filename           File to create the object from
+     * @param string $section            If not null, pull this sestion of the config
+     * file only. Dosn't apply to .php and .inc file
+     * @param string $allowModifications Should the object be mutable or not
+     * @throws Akrabat_Db_Schema_Exception
+     * @return Zend_Config
+     */
+    protected function _createConfig($filename, $section = null, $allowModifications = false) {
+
+        $options = false;
+        if ($allowModifications) {
+            $options = array('allowModifications' => true);
+        }
+
+        $suffix = pathinfo($filename, PATHINFO_EXTENSION);
+        $suffix  = ($suffix === 'dist')
+                 ? pathinfo(basename($filename, ".$suffix"), PATHINFO_EXTENSION)
+                 : $suffix;
+
+        switch (strtolower($suffix)) {
+            case 'ini':
+                $config = new Zend_Config_Ini($filename, $section, $options);
+                break;
+
+            case 'xml':
+                $config = new Zend_Config_Xml($filename, $section, $options);
+                break;
+
+            case 'json':
+                $config = new Zend_Config_Json($filename, $section, $options);
+                break;
+
+            case 'yaml':
+            case 'yml':
+                $config = new Zend_Config_Yaml($filename, $section, $options);
+                break;
+
+            case 'php':
+            case 'inc':
+                $config = include $filename;
+                if (!is_array($config)) {
+                    throw new Akrabat_Db_Schema_Exception(
+                        'Invalid configuration file provided; PHP file does not return array value'
+                    );
+                }
+                $config = new Zend_Config($config, $allowModifications);
+                break;
+
+            default:
+                throw new Akrabat_Db_Schema_Exception(
+                    'Invalid configuration file provided; unknown config type'
+                );
+        }
+        return $config;
+    }
+
+    /**
+     * Will pull a list of file paths to application config overrides
+     *
+     * There is a deliberate attempt to be very forgiving. If a file doesn’t exist,
+     * it won't be included in the list. If a the file doesn’t have a section that
+     * corresponds the current target environment it don't be merged.
+     *
+     * The config files should be standalone, they will not be able to extend
+     * sections from the base config file.
+     *
+     * The ini, xml, json, yaml and php config file types are supported
+     *
+     * By default we will look for a "local.ini" in the applications configs
+     * directory.
+     *
+     * Config files are added with an order, the order run from lowest to highest.
+     * The "local.ini" file in this case will be given the order of 100
+     *
+     * This can be disabled with the following in your .zf.ini:
+     *
+     * akrabat.appConfigOverride.skipLocal = true
+     *
+     * You can have add to the list of file names to look for in the configs
+     * directory by adding the following to the .zf.ini:
+     *
+     * akrabat.appConfigOverride.name = 'override.ini'
+     *
+     * You can only add one name with this approach and it will be added with the
+     * order of 200
+     *
+     * To add mutiple names to be checked use the following in the .zf.ini:
+     *
+     * akrabat.appConfigOverride.name.60 = 'dev.ini'
+     * akrabat.appConfigOverride.name.50 = 'override.ini.ini'
+     *
+     * Where the last part of the config key is the order to merge the files.
+     *
+     * To add a path to be include, do the following in your .zf.ini:
+     *
+     * akrabat.appConfigOverride.path = '/home/user/projects/account/configs/local.ini'
+     *
+     * You can only add one path with this approach and it will be added with the
+     * order of 300
+     *
+     * To add mutiple path use the following in the .zf.ini:
+     *
+     * akrabat.appConfigOverride.path.1 = './application/configs/dev.ini'
+     * akrabat.appConfigOverride.path.4 = '/home/user/projects/account/configs/local.ini'
+     *
+     * Where the last part of the config key is the order to merge the files.
+     *
+     * If a path is added that's order clashes with another file then the path will
+     * be added the end of the queue
+     *
+     * @param string $appConfigFilePath
+     * @return array
+     */
+    protected function _getAppConfigOverridePathList($appConfigFilePath)
+    {
+        $pathList     = array();
+        $appConfigDir = dirname($appConfigFilePath);
+        $userConfig   = false;
+
+        if ($this->_getUserConfig() !== false
+            && isset($this->_getUserConfig()->appConfigOverride)
+        ) {
+            $userConfig = $this->_getUserConfig()->appConfigOverride;
+        }
+
+        $skipLocal = false;
+        if ($userConfig !== false && isset($userConfig->skipLocal)) {
+            $skipLocal = (bool)$userConfig->skipLocal;
+        }
+
+        // The convention over configuration option
+        if ($skipLocal === false) {
+            $appConfigFilePathLocal = realpath($appConfigDir.'/local.ini');
+            if ($appConfigFilePathLocal) {
+                $pathList[100] = $appConfigFilePathLocal;
+            }
+        }
+
+        if ($userConfig === false) {
+            return $pathList;
+        }
+
+        // Look for file names in the app configs dir
+        if (isset($userConfig->name)) {
+            if ($userConfig->name instanceof Zend_Config) {
+                $fileNameList = $userConfig->name->toArray();
+            } else {
+                $fileNameList = array(200 => $userConfig->name);
+            }
+
+            foreach($fileNameList as $order => $fileName) {
+                $path = realpath($appConfigDir.'/'.$fileName);
+                if ($path) {
+                    $pathList[$order] = $appConfigDir.'/'.$fileName;
+                }
+            }
+        }
+
+        // A full or relative path, app dir will not be prefixed
+        if (isset($userConfig->path)) {
+            if ($userConfig->path instanceof Zend_Config) {
+                $filePathList = $userConfig->path->toArray();
+            } else {
+                $filePathList = array(300 => $userConfig->path);
+            }
+
+            foreach($filePathList as $order => $filePath) {
+                if (file_exists($filePath) === false) {
+                    continue;
+                }
+                if (isset($pathList[$order])) {
+                    $pathList[] = $filePath;
+                } else {
+                    $pathList[$order] = $filePath;
+                }
+            }
+        }
+
+        ksort($pathList);
+        return $pathList;
     }
 
     /**


### PR DESCRIPTION
Added support for a local.ini config file in the application that will allow overrides of the default application.ini

Used to allow developers using a local database to have somewhere to put there db config with out it being in source control.

Let me know if you have any feedback to improve.
