### PR TITLE
Added features for Akrabat database migrations

### DIFF
--- a/zf1/Akrabat/Tool/DatabaseSchemaProvider.php
+++ b/zf1/Akrabat/Tool/DatabaseSchemaProvider.php
@@ -61,26 +61,7 @@ class Akrabat_Tool_DatabaseSchemaProvider extends Zend_Tool_Project_Provider_Abs
         }
     }
 
-    public function decrement($env='development', $dir='./scripts/migrations')
-    {
-    	$this->_init($env);
-    	try {
-    		$db = $this->_getDbAdapter();
-    		$manager = new Akrabat_Db_Schema_Manager($dir, $db, $this->getTablePrefix());
-    		$version = $manager->getCurrentSchemaVersion();
-    		if ($version > 0) {
-	    		return $this->updateTo($version - 1, $env, $dir);
-    		}
-    		echo 'Schema is already at version 0' . PHP_EOL;
-    		return false;
-    	} catch (Exception $e) {
-    		echo 'AN ERROR HAS OCCURRED:' . PHP_EOL;
-    		echo $e->getMessage() . PHP_EOL;
-    		return false;
-    	}
-    }
-    
-    public function increment($env='development', $dir='./scripts/migrations')
+    public function decrement($versions=1, $env='development', $dir='./scripts/migrations')
     {
     	$this->_init($env);
         $response = $this->_registry->getResponse();
@@ -88,7 +69,34 @@ class Akrabat_Tool_DatabaseSchemaProvider extends Zend_Tool_Project_Provider_Abs
             $db = $this->_getDbAdapter();
             $manager = new Akrabat_Db_Schema_Manager($dir, $db, $this->getTablePrefix());
 
-            $result = $manager->incrementVersion();
+            $result = $manager->decrementVersion($versions);
+
+            switch ($result) {
+                case Akrabat_Db_Schema_Manager::RESULT_AT_MINIMUM_VERSION:
+                    $response->appendContent("Already at minimum version " . $manager->getCurrentSchemaVersion());
+                    break;
+
+                default:
+                    $response->appendContent('Schema updated to version ' . $manager->getCurrentSchemaVersion());
+            }
+
+            return true;
+        } catch (Exception $e) {
+            $response->appendContent('AN ERROR HAS OCCURED: ');
+            $response->appendContent($e->getMessage());
+            return false;
+        }
+    }
+    
+    public function increment($versions=1,$env='development', $dir='./scripts/migrations')
+    {
+    	$this->_init($env);
+        $response = $this->_registry->getResponse();
+        try {
+            $db = $this->_getDbAdapter();
+            $manager = new Akrabat_Db_Schema_Manager($dir, $db, $this->getTablePrefix());
+
+            $result = $manager->incrementVersion($versions);
 
             switch ($result) {
                 case Akrabat_Db_Schema_Manager::RESULT_AT_MAXIMUM_VERSION:

--- a/zf1/Akrabat/Tool/DatabaseSchemaProvider.php
+++ b/zf1/Akrabat/Tool/DatabaseSchemaProvider.php
@@ -61,9 +61,54 @@ class Akrabat_Tool_DatabaseSchemaProvider extends Zend_Tool_Project_Provider_Abs
         }
     }
 
+    public function decrement($env='development', $dir='./scripts/migrations')
+    {
+    	$this->_init($env);
+    	try {
+    		$db = $this->_getDbAdapter();
+    		$manager = new Akrabat_Db_Schema_Manager($dir, $db, $this->getTablePrefix());
+    		$version = $manager->getCurrentSchemaVersion();
+    		if ($version > 0) {
+	    		return $this->updateTo($version - 1, $env, $dir);
+    		}
+    		echo 'Schema is already at version 0' . PHP_EOL;
+    		return false;
+    	} catch (Exception $e) {
+    		echo 'AN ERROR HAS OCCURRED:' . PHP_EOL;
+    		echo $e->getMessage() . PHP_EOL;
+    		return false;
+    	}
+    }
+    
+    public function increment($env='development', $dir='./scripts/migrations')
+    {
+    	$this->_init($env);
+        $response = $this->_registry->getResponse();
+        try {
+            $db = $this->_getDbAdapter();
+            $manager = new Akrabat_Db_Schema_Manager($dir, $db, $this->getTablePrefix());
 
+            $result = $manager->incrementVersion();
+
+            switch ($result) {
+                case Akrabat_Db_Schema_Manager::RESULT_AT_MAXIMUM_VERSION:
+                    $response->appendContent("Already at maximum version " . $manager->getCurrentSchemaVersion());
+                    break;
+
+                default:
+                    $response->appendContent('Schema updated to version ' . $manager->getCurrentSchemaVersion());
+            }
+
+            return true;
+        } catch (Exception $e) {
+            $response->appendContent('AN ERROR HAS OCCURED:');
+            $response->appendContent($e->getMessage());
+            return false;
+        }
+    }
+    
     /**
-     * Provide the current schama version number
+     * Provide the current schema version number
      */
     public function current($env='development', $dir='./migrations')
     {


### PR DESCRIPTION
These changes include a number of new features. I can split them out into individual features if desired.

1) Allow increment of versions. You can imcrement one or more versions. ie,

zf increment database-schema

(increases to the next version number unless already at the maximum)
or 

zf increment database-schema 2

(goes up 2 versions)

2) Allow decrement of versions. Like increment, you can decrement 1 or more versions.

zf decrement database-schema 4
(goes down 4 versions)

3) Downgrades update the version to the number that really exists. For instance if there are versions 1, 5, 10 and 15 and you are on 15, previously update-to 14 would put 14 in the database and remove version 15. This will indicate on the screen and in the database that the version is actually 10.

4) Checks if scripts directory is a directory and is readable before trying to find migration files. Previously this would bomb out with several warnings and issues showing in the console.

Thanks for creating this tool. I hope these changes are useful for you.

Thanks,
David
