### PR TITLE
Fix for finding real version on downgrade migrations.

### DIFF
--- a/zf1/Akrabat/Db/Schema/Manager.php
+++ b/zf1/Akrabat/Db/Schema/Manager.php
@@ -104,11 +104,11 @@ class Akrabat_Db_Schema_Manager
         // figure out what the real version we're going to is if going down
         if ($direction == 'down') {
         	$files = $this->_getMigrationFiles($version, 0);
-        	$versionFile = array_shift($files);
-        	if (!empty($files)) {
-        		$realVersion = $versionFile['version'];
-        	} else {
+        	if (empty($files)) {
         		$realVersion = 0;
+        	} else {
+            	$versionFile = array_shift($files);
+        		$realVersion = $versionFile['version'];
         	}
         	// update the database to the version we're actually at
         	$this->_updateSchemaVersion($realVersion);


### PR DESCRIPTION
Fix for finding real version on downgrade migrations. Bug happened if migrating to lowest version number and version > 0.

If _getMigration files only returns a single file, the array_shift would pull it off and then the following check for if $files contains stuff would fail and it would say the version is 0.

This fixes that so that you can downgrade to the lowest version (that exists) even if that version is > 0.
