### PR TITLE
disallow multiple occurrences of the same version

### DIFF
--- a/library/Akrabat/Db/Schema/Manager.php
+++ b/library/Akrabat/Db/Schema/Manager.php
@@ -224,6 +224,8 @@ class Akrabat_Db_Schema_Manager
      * @param string $stopVersion    Version to migrate database to
      * @param string $dir            Directory containing migration files
      * 
+     * @throws Akrabat_Db_Schema_Exception
+     * 
      * @return array of file name, version and class name
      */
     protected function _getMigrationFiles($currentVersion, $stopVersion, $dir = null)
@@ -247,9 +249,14 @@ class Akrabat_Db_Schema_Manager
         } 
         
         $d = dir($dir);
+        $seen = array();
         while (false !== ($entry = $d->read())) {
             if (preg_match('/^([0-9]+)\-(.*)\.php/i', $entry, $matches) ) {
                 $versionNumber = (int)$matches[1];
+                if (isset($seen[$versionNumber])) {
+                    throw new Akrabat_Db_Schema_Exception("version $versionNumber is used for multiple migrations.");
+                }
+                $seen[$versionNumber];
                 $className = $matches[2];
                 if ($versionNumber > $from && $versionNumber <= $to) {
                     $path = $this->_relativePath($this->_dir, $dir);


### PR DESCRIPTION
If two migrations exist, say, `005-AddTable.php` and `005-AddIndex.php`, Akrabat will execute the first one returned by `dir()->read()`, and ignore the second. This may cause confusion if two devs accidentally created migrations with conflicting version numbers and the problem wasn't noticed before the database was upgraded to version 5.

This patch prevents accidental creation of multiple upgrade scripts with the same version number.
