### PR TITLE
fix duplicate migration check (fix my last fix)

### DIFF
--- a/library/Akrabat/Db/Schema/Manager.php
+++ b/library/Akrabat/Db/Schema/Manager.php
@@ -256,7 +256,7 @@ class Akrabat_Db_Schema_Manager
                 if (isset($seen[$versionNumber])) {
                     throw new Akrabat_Db_Schema_Exception("version $versionNumber is used for multiple migrations.");
                 }
-                $seen[$versionNumber];
+                $seen[$versionNumber] = true;
                 $className = $matches[2];
                 if ($versionNumber > $from && $versionNumber <= $to) {
                     $path = $this->_relativePath($this->_dir, $dir);


### PR DESCRIPTION
There was an error in [my] commit 019e2c466682d8fa6e9341a49eb2ba9ab9534601 .
I used a meaningless array access instead of actually adding values to
the $seen array for later duplicate checks.

Typical warning shown when this occurs:

```
PHP Notice:  Undefined offset: 18 in /path/to/library/Akrabat/Db/Schema/Manager.php on line 265
```
